### PR TITLE
Ran rake db:migrate:reset to remove microposts from db/schema.rb; remove...

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -29,12 +29,8 @@ guard :minitest, spring: true, all_on_start: false do
   watch('app/controllers/account_activations_controller.rb') do
     'test/integration/users_signup_test.rb'
   end
-  watch('app/models/micropost.rb') do
-    ['test/models/micropost_test.rb', 'test/models/user_test.rb']
-  end
   watch(%r{app/views/users/*}) do
-    resource_tests('users') +
-    ['test/integration/microposts_interface_test.rb']
+    resource_tests('users')
   end
 end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,18 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141111014949) do
-
-  create_table "microposts", force: :cascade do |t|
-    t.text     "content"
-    t.integer  "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string   "picture"
-  end
-
-  add_index "microposts", ["user_id", "created_at"], name: "index_microposts_on_user_id_and_created_at"
-  add_index "microposts", ["user_id"], name: "index_microposts_on_user_id"
+ActiveRecord::Schema.define(version: 20141107180258) do
 
   create_table "users", force: :cascade do |t|
     t.string   "name"


### PR DESCRIPTION
...d references to microposts from Guardfile

These changes are for the account-activation-password-reset branch ONLY.  I am using this specific branch for a rapid prototyping gem (https://github.com/jhsu802701/generic_app) that uses a generic Rails app (the railstutorial.org sample app BEFORE the addition of microposts and relationships) as a template for starting any specific Rails app.  Using my special rapid prototyping gem creates a general app with user functionality, Twitter bootstrap, tests, Guard, account activations, password resets, and other features in SECONDS instead of hours.