### PR TITLE
css mixin deprecated

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -1,15 +1,9 @@
 @import "bootstrap-sprockets";
 @import "bootstrap";
 
-/* mixins, variables, etc. */
+/* variables, etc. */
 
 $gray-medium-light: #eaeaea;
-
-@mixin box_sizing {
-  -moz-box-sizing:    border-box;
-  -webkit-box-sizing: border-box;
-  box-sizing:         border-box;
-}
 
 /* universal */
 
@@ -114,7 +108,7 @@ footer {
   float: left;
   width: 100%;
   margin-top: 45px;
-  @include box_sizing;
+  box-sizing: border-box;
 }
 
 /* sidebar */
@@ -198,7 +192,7 @@ input, textarea, select, .uneditable-input {
   border: 1px solid #bbb;
   width: 100%;
   margin-bottom: 15px;
-  @include box_sizing;
+  box-sizing: border-box;
 }
 
 input {


### PR DESCRIPTION
"The mixin is deprecated as of v3.2.0, with the introduction of autoprefixer."
http://getbootstrap.com/css/#less-mixins-box-sizing