### PR TITLE
Set mailer default URL protocol to HTTPS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,6 +350,3 @@ DEPENDENCIES
   uglifier (= 2.5.3)
   web-console (= 2.0.0.beta3)
   will_paginate (= 3.0.7)
-
-BUNDLED WITH
-   1.10.6

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,8 +15,8 @@ Rails.application.configure do
 
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :test
-  host = 'rails-tutorial-c9-mhartl.c9.io'
-  config.action_mailer.default_url_options = { host: host }
+  host = 'rails-tutorial-account-activation-tacos1998.c9users.io'
+  config.action_mailer.default_url_options = { host: host, protocol: 'https' }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log


### PR DESCRIPTION
I'm not sure what happened to `Gemfile.lock`, but the code in `config/environments/development.rb` sets the default protocol for the account activation (and all other) email links to HTTPS (I had to edit the "host" variable to get the links to work on my workspace). Previously, the default was HTTP, and upon clicking the link I was redirected to the homepage (with the "Invalid activation link" behavior), but the new user's "activated" attribute was set to "true" (verified with the rails console before and after visiting the URL) and I was able to log in without any redirects, error messages, etc. All tests have passed before and after this implementation.

This behavior occurred using Rails 4.2.2 with the Cloud9 IDE in Google Chrome.